### PR TITLE
Add support for Python 3.

### DIFF
--- a/stetl/chain.py
+++ b/stetl/chain.py
@@ -5,9 +5,18 @@
 # Author: Just van den Broecke
 #
 
-from factory import factory
-from packet import Packet
-from util import Util
+try:
+    from factory import factory
+except ImportError:
+    from .factory import factory
+try:
+    from packet import Packet
+except ImportError:
+    from .packet import Packet
+try:
+    from util import Util
+except ImportError:
+    from .util import Util
 
 log = Util.get_log('chain')
 
@@ -79,7 +88,7 @@ class Chain:
                 packet.init()
                 packet = self.first_comp.process(packet)
                 rounds += 1
-                #            except (Exception), e:
+                #            except (Exception) as e:
             #                log.error("Fatal Error in ETL: %s"% str(e))
             #                break
         finally:

--- a/stetl/component.py
+++ b/stetl/component.py
@@ -5,8 +5,14 @@
 # Author: Just van den Broecke
 #
 import os
-from util import Util, ConfigSection
-from packet import FORMAT
+try:
+    from util import Util, ConfigSection
+except ImportError:
+    from .util import Util, ConfigSection
+try:
+    from packet import FORMAT
+except ImportError:
+    from .packet import FORMAT
 
 log = Util.get_log('component')
 

--- a/stetl/etl.py
+++ b/stetl/etl.py
@@ -6,11 +6,26 @@
 #
 import os
 import sys
-from ConfigParser import ConfigParser
-import version
-from util import Util
-from chain import Chain
-import StringIO
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+try:
+    from version import __version__
+except ImportError:
+    from .version import __version__
+try:
+    from util import Util
+except ImportError:
+    from .util import Util
+try:
+    from chain import Chain
+except ImportError:
+    from .chain import Chain
+try:
+    import StringIO
+except ImportError:
+    from io import StringIO
 
 log = Util.get_log('ETL')
 
@@ -33,7 +48,7 @@ class ETL:
         """
         # args_dict is optional and is used to do string substitutions in options_dict.config file
 
-        log.info("INIT - Stetl version is %s" % str(version.__version__))
+        log.info("INIT - Stetl version is %s" % __version__)
 
         self.options_dict = options_dict
         config_file = self.options_dict.get('config_file')
@@ -70,7 +85,7 @@ class ETL:
             else:
                 # Parse config file directly
                 self.configdict.read(config_file)
-        except Exception, e:
+        except (Exception) as e:
             log.error("Fatal Error reading config file: err=%s" % str(e))
 
 

--- a/stetl/factory.py
+++ b/stetl/factory.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from util import Util
+try:
+    from util import Util
+except ImportError:
+    from .util import Util
 
 log = Util.get_log('factory')
 
@@ -24,7 +27,7 @@ class Factory:
 
             # class instance from class object with constructor args
             class_obj_inst = self.new_instance(class_obj, configdict, section)
-        except Exception, e:
+        except (Exception) as e:
             log.error("cannot create object instance from class '%s' e=%s" % (class_string, str(e)))
             raise e
 
@@ -46,7 +49,7 @@ class Factory:
                 raise ValueError('Class name must contain module part.')
             class_obj = getattr(
                 __import__(module_name, globals(), locals(), [class_name], -1), class_name)
-        except Exception, e:
+        except (Exception) as e:
             log.error("cannot create class '%s'" % class_string)
             raise e
 

--- a/stetl/filter.py
+++ b/stetl/filter.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 # Author: Just van den Broecke
 #
-from component import Component
+
+try:
+    from component import Component
+except ImportError:
+    from .component import Component
 
 
 class Filter(Component):

--- a/stetl/filters/gmlsplitter.py
+++ b/stetl/filters/gmlsplitter.py
@@ -127,13 +127,13 @@ class GmlSplitter(Filter):
             # print '[' + self.buffer.getvalue() + ']'
             packet.data = etree.parse(self.buffer, self.xml_parser)
         #            print buffer.getvalue()
-        except Exception, e:
+        except (Exception) as e:
             bufStr = self.buffer.getvalue()
             if not bufStr:
                 log.info("parse buffer empty: content=[%s]" % bufStr)
             else:
                 log.error("error in buffer parsing %s" % str(e))
-                print bufStr
+                print (bufStr)
                 raise
         self.buffer.close()
         self.buffer = None

--- a/stetl/filters/templatingfilter.py
+++ b/stetl/filters/templatingfilter.py
@@ -170,7 +170,7 @@ class Jinja2TemplatingFilter(TemplatingFilter):
     def create_template(self):
         try:
             from jinja2 import Environment, FileSystemLoader
-        except Exception, e:
+        except (Exception) as e:
             log.error(
                 'Cannot import modules from Jinja2, err= %s; You probably need to install Jinja2 first, see http://jinja.pocoo.org',
                 str(e))
@@ -206,7 +206,7 @@ class Jinja2TemplatingFilter(TemplatingFilter):
                     else:
                         template_globals.update(globals_struct)
 
-                except Exception, e:
+                except (Exception) as e:
                     log.error('Cannot read JSON file, err= %s', str(e))
                     raise e
 
@@ -297,7 +297,7 @@ class Jinja2TemplatingFilter(TemplatingFilter):
                 options.append('GMLID=%s' % gml_id)
 
             gml_str = geom.ExportToGML(options=options)
-        except Exception, e:
+        except (Exception) as e:
             gml_str = 'Failure in CreateGeometryFromJson or ExportToGML, err= %s; check your data and Stetl log' % str(
                 e)
             log.error(gml_str)

--- a/stetl/filters/xmlassembler.py
+++ b/stetl/filters/xmlassembler.py
@@ -65,7 +65,7 @@ class XmlAssembler(Filter):
         # Start new doc (TODO clone)
         try:
             etree_doc = etree.fromstring(self.container_doc, self.xml_parser)
-        except Exception, e:
+        except (Exception) as e:
             log.error("new container doc not OK")
             return packet
 

--- a/stetl/input.py
+++ b/stetl/input.py
@@ -4,8 +4,15 @@
 #
 # Author: Just van den Broecke
 #
-from util import Util
-from component import Component
+
+try:
+    from util import Util
+except ImportError:
+    from .util import Util
+try:
+    from component import Component
+except ImportError:
+    from .component import Component
 
 log = Util.get_log('input')
 

--- a/stetl/inputs/deegreeinput.py
+++ b/stetl/inputs/deegreeinput.py
@@ -155,13 +155,13 @@ class DeegreeBlobstoreInput(Input):
             # print '[' + self.buffer.getvalue() + ']'
             packet.data = etree.parse(self.buffer, self.xml_parser)
         #            print buffer.getvalue()
-        except Exception, e:
+        except (Exception) as e:
             bufStr = self.buffer.getvalue()
             if not bufStr:
                 log.info("parse buffer empty: content=[%s]" % bufStr)
             else:
                 log.error("error in buffer parsing %s" % str(e))
-                print bufStr
+                print (bufStr)
                 raise
         self.buffer.close()
         self.buffer = None

--- a/stetl/inputs/fileinput.py
+++ b/stetl/inputs/fileinput.py
@@ -180,7 +180,7 @@ class XmlFileInput(FileInput):
         data = None
         try:
             data = etree.parse(file_path)
-        except Exception, e:
+        except (Exception) as e:
             log.info("file read and parsed NOT OK : %s" % file_path)
 
         return data
@@ -428,7 +428,7 @@ class CsvFileInput(FileInput):
                     packet.data = self.csv_reader.next()
 
             log.info("CSV row nr %d read: %s" % (self.csv_reader.line_num - 1, packet.data))
-        except Exception, e:
+        except (Exception) as e:
             if self._output_format == FORMAT.record_array:
                 packet.data = self.arr
 
@@ -466,7 +466,7 @@ class JsonFileInput(FileInput):
                 with open(file_path) as data_file:
                     file_data = json.load(data_file)
 
-        except Exception, e:
+        except (Exception) as e:
             log.error('Cannot read JSON from %s, err= %s' % (file_path, str(e)))
             raise e
 

--- a/stetl/inputs/httpinput.py
+++ b/stetl/inputs/httpinput.py
@@ -88,10 +88,10 @@ class HttpInput(Input):
                 query_string = urllib.urlencode(parameters)
 
             response = urlopen(req, query_string)
-        except HTTPError as e:
+        except (HTTPError) as e:
             log.error('HTTPError fetching from URL %s: code=%d e=%s' % (url, e.code, e))
             raise e
-        except URLError as e:
+        except (URLError) as e:
             log.error('URLError fetching from URL %s: reason=%s e=%s' % (url, e.reason, e))
             raise e
 

--- a/stetl/main.py
+++ b/stetl/main.py
@@ -5,10 +5,23 @@
 #
 # Author: Just van den Broecke
 #
-from etl import ETL
-from factory import factory
-from util import Util
-from version import __version__
+
+try:
+    from etl import ETL
+except ImportError:
+    from .etl import ETL
+try:
+    from factory import factory
+except ImportError:
+    from .factory import factory
+try:
+    from util import Util
+except ImportError:
+    from .util import Util
+try:
+    from version import __version__
+except ImportError:
+    from .version import __version__
 import argparse #apt-get install python-argparse
 import inspect
 import os
@@ -85,7 +98,7 @@ def print_classes(package):
         for name, data in inspect.getmembers(modname, inspect.isclass):
             if name == '__builtins__':
                 continue
-            print name, data
+            print (name, data)
 
 
 # DEPRECATED, now using @Config which also documents with Sphinx
@@ -103,7 +116,7 @@ def print_doc(class_name):
         # print ('\nConfiguration attributes: \n')
         # print_config_attrs(class_obj)
 
-    except Exception, e:
+    except (Exception) as e:
         log.error("cannot print info class named '%s' e=%s - you made a typo?" % (class_name, str(e)))
         raise e
 

--- a/stetl/output.py
+++ b/stetl/output.py
@@ -4,8 +4,15 @@
 #
 # Author: Just van den Broecke
 #
-from component import Component
-from util import Util, etree
+
+try:
+    from component import Component
+except ImportError:
+    from .component import Component
+try:
+    from util import Util, etree
+except ImportError:
+    from .util import Util, etree
 
 log = Util.get_log('output')
 

--- a/stetl/packet.py
+++ b/stetl/packet.py
@@ -4,7 +4,11 @@
 #
 # Author: Just van den Broecke
 #
-from util import etree
+
+try:
+    from util import etree
+except ImportError:
+    from .util import etree
 import json
 
 class Packet:

--- a/stetl/postgis.py
+++ b/stetl/postgis.py
@@ -4,7 +4,11 @@
 #
 # Author: Just van den Broecke
 #
-from util import Util
+
+try:
+    from util import Util
+except ImportError:
+    from .util import Util
 
 log = Util.get_log("postgis")
 
@@ -31,7 +35,7 @@ class PostGIS:
             self.cursor.execute(script)
             self.connection.commit()
             log.info('script executed')
-        except psycopg2.DatabaseError, e:
+        except (psycopg2.DatabaseError) as e:
             log.warn("error '%s' from script '%s'" % (str(e), str(bestand)))
 
     def connect(self, initdb=False):
@@ -47,14 +51,14 @@ class PostGIS:
 
             self.set_schema()
             log.debug("Connected to database %s" % (self.config['database']))
-        except Exception, e:
+        except (Exception) as e:
             log.error("Cannot connect to database '%s'" % (self.config['database']))
 
     def disconnect(self):
         self.e = None
         try:
             self.connection.close()
-        except (Exception), e:
+        except (Exception) as e:
             self.e = e
             log.error("error %s in close" % (str(e)))
 
@@ -66,7 +70,7 @@ class PostGIS:
             self.connection.commit()
             if close is True:
                 self.connection.close()
-        except (Exception), e:
+        except (Exception) as e:
             self.e = e
             log.error("error %s in commit" % (str(e)))
 
@@ -120,7 +124,7 @@ class PostGIS:
                 self.cursor.execute(sql)
 
                 # log.debug(self.cursor.statusmessage)
-        except (Exception), e:
+        except (Exception) as e:
             log.error("error %s in query: %s with params: %s" % (str(e), str(sql), str(parameters)))
             #            self.log_actie("uitvoeren_db", "n.v.t", "fout=%s" % str(e), True)
             return -1
@@ -139,7 +143,7 @@ class PostGIS:
             self.connection.commit()
             f.close()
             log.info("SQL executed OK")
-        except (Exception), e:
+        except (Exception) as e:
             self.e = e
             self.log_action("file_execute", "n.v.t", "fout=%s" % str(e), True)
             log.warn("can't execute SQL script, error: %s" % (str(e)))
@@ -154,7 +158,7 @@ class PostGIS:
             self.connection.close()
 
             # log.debug(self.cursor.statusmessage)
-        except (Exception), e:
+        except (Exception) as e:
             self.e = e
             log.error("error %s in transaction: %s with parms: %s" % (str(e), str(sql), str(parameters)))
 

--- a/stetl/util.py
+++ b/stetl/util.py
@@ -342,10 +342,13 @@ try:
     from cStringIO import StringIO
 
     log.info("Found cStringIO, good!")
-except:
-    from StringIO import StringIO
+except ImportError:
+    try:
+        from StringIO import StringIO
 
-    log.warning("Found StringIO (this is suboptimal, try cStringIO")
+        log.warning("Found StringIO (this is suboptimal, try cStringIO")
+    except ImportError:
+        from io import StringIO
 
 try:
     from lxml import etree

--- a/stetl/utils/apachelog.py
+++ b/stetl/utils/apachelog.py
@@ -180,7 +180,7 @@ class parser:
         self._pattern = '^' + ' '.join(subpatterns) + '$'
         try:
             self._regex = re.compile(self._pattern)
-        except Exception, e:
+        except (Exception) as e:
             raise ApacheLogParserError(e)
 
     def parse(self, line):


### PR DESCRIPTION
As reported in #23, stetl doesn't support Python 3 yet. This PR adds initial support for Python 3 following the [Supporting Python 2 and 3 without 2to3 conversion](http://python3porting.com/noconv.html) guidelines.

The Python 3 code generated by [2to3](http://python3porting.com/2to3.html) makes additional changes like these:

``` diff
--- stetl/component.py  2015-11-14 03:26:07.996019556 +0100
+++ /tmp/python3-stetl/stetl/component.py       2015-11-14 01:05:59.158693458 +0100
@@ -146,12 +140,12 @@

         if not self.is_compatible():
             raise ValueError(
-                'Incompatible components are linked: %s and %s' % (str(self), str(self.next)))
+                'Incompatible components are linked: %s and %s' % (str(self), str(self.__next__)))

     # Check our compatibility with the next Component in the Chain
     def is_compatible(self):
         # Ok, nothing next in Chain
-        if self.next is None or self._output_format is FORMAT.none or self.next._input_format == FORMAT.any:
+        if self.__next__ is None or self._output_format is FORMAT.none or self.next._input_format == FORMAT.any:
             return True

         # return if our Output is compatible with the next Component's Input
--- stetl/filters/formatconverter.py    2015-11-14 03:23:01.344947046 +0100
+++ /tmp/python3-stetl/stetl/filters/formatconverter.py 2015-11-14 01:05:59.790690136 +0100
@@ -55,12 +55,12 @@
             return

         # generate runtime error as we may have registered converters at init time...
-        if self.input_format not in FORMAT_CONVERTERS.keys():
+        if self.input_format not in list(FORMAT_CONVERTERS.keys()):
             raise NotImplementedError('No format converters found for input format %s' % self.input_format)

         # ASSERTION: converters present for input_format

-        if self.output_format not in FORMAT_CONVERTERS[self.input_format].keys():
+        if self.output_format not in list(FORMAT_CONVERTERS[self.input_format].keys()):
             raise NotImplementedError('No format converters found for input format %s to output format %s' % (
                 self.input_format, self.output_format))

@@ -213,7 +213,7 @@
             for field_name in json_props:

                 # OGR needs UTF-8 internally
-                if isinstance(field_name, unicode):
+                if isinstance(field_name, str):
                     field_name = field_name.encode('utf8')

                 field_def = ogr.FieldDefn(field_name, ogr.OFTString)
--- stetl/filters/templatingfilter.py   2015-11-14 03:26:07.996019556 +0100
+++ /tmp/python3-stetl/stetl/filters/templatingfilter.py        2015-11-14 01:06:00.014688958 +0100
@@ -192,9 +192,9 @@
                     log.info('Read JSON file with globals from: %s', file_path)
                     # Globals can come from local file or remote URL
                     if file_path.startswith('http'):
-                        import urllib2
+                        import urllib.request, urllib.error, urllib.parse

-                        fp = urllib2.urlopen(file_path)
+                        fp = urllib.request.urlopen(file_path)
                         globals_struct = json.loads(fp.read())
                     else:
                         with open(file_path) as data_file:
```

But changes like the above haven't been included so far.

With the initial Python 3 support stetl builds successfully with Python 2.7, 3.4 & 3.5 (on Debian unstable), the single nose test also succeeds with all three interpreters.
