### PR TITLE
Issue 49 correction

### DIFF
--- a/stetl/filters/xmlassembler.py
+++ b/stetl/filters/xmlassembler.py
@@ -39,6 +39,10 @@ class XmlAssembler(Filter):
             # Valid element: consume and handle
             self.consume_element(packet)
 
+            # Document is obviously not finished, reset EoD/EoS in packet
+            packet.set_end_of_stream(False)
+            packet.set_end_of_doc(False)
+
         if packet.is_end_of_stream() or packet.is_end_of_doc() or len(self.element_arr) >= self.max_elements:
             # EOF but still data in buffer: make doc
             # log.info("Flush doc")


### PR DESCRIPTION
While loading BGT data yesterday, I noticed that, after an XML file has been assembled using XmlAssembler, every subsequent XML file will only contain one feature. The cause is that somewhere in the ETL chain end_of_document or end_of_stream is set in the packet. Or rather, packet.init is not called, as it is called in my unit tests. I suspect this is due to the use of the ZipFileInput in the real life situation (BGT extract), instead of XmlElementStreamerFileInput in XmlAssemblerTest (test_xml_assembler.py). Before the XML is being processed, the ZIP file has already been entirely "read".

I think my fix is justifiable, although I still consider it as a workaround. When more XML elements are being read, it is obvious that End of Document, or End of Stream has not been reach yet.

A more permanent solution would be the redesign mentioned in issue #51.