### PR TITLE
Solving memory issue caused by PR #54

### DIFF
--- a/stetl/filters/xmlassembler.py
+++ b/stetl/filters/xmlassembler.py
@@ -5,6 +5,8 @@
 #
 # Author: Just van den Broecke
 #
+from lxml import etree
+
 from stetl.util import Util, etree
 from stetl.filter import Filter
 from stetl.packet import FORMAT
@@ -54,7 +56,7 @@ class XmlAssembler(Filter):
         # Always move the data (element) from packet
         element = packet.consume()
 
-        if element is not None:
+        if element is not None and etree.iselement(element):
             self.total_element_count += 1
             self.element_arr.append(element)
 

--- a/stetl/filters/xmlelementreader.py
+++ b/stetl/filters/xmlelementreader.py
@@ -118,7 +118,7 @@ class XmlElementReader(Filter):
                     self.elem_count += 1
 
                     if self.strip_namespaces:
-                        packet.data = Util.stripNamespaces(elem).getroot()
+                        packet.data = Util.stripNamespaces(packet.data).getroot()
 
             # If there is a next component, let it process
             if self.next:

--- a/stetl/filters/xmlelementreader.py
+++ b/stetl/filters/xmlelementreader.py
@@ -116,6 +116,7 @@ class XmlElementReader(Filter):
                 elif event == "end":
                     packet.data = deepcopy(elem)
                     self.elem_count += 1
+                    elem.clear()
 
                     if self.strip_namespaces:
                         packet.data = Util.stripNamespaces(packet.data).getroot()


### PR DESCRIPTION
It turned out that PR #54 caused too much memory to be consumed, leading to out of memory exceptions. Very obvious, so sorry for that :) Anyways, the originally processed element should be cleared. This can safely be done, as opposed to reusing it in a new XML document.
Also, when stripping namespaces, this should be done on the cloned element.
Furthermore, while testing locally, I also discovered that sometimes a string object (containing the name of the document being generated) is passed to XmlAssembler. I'm not sure what the cause is, so I'm just testing whether the object is a real XML element.

Now the memory stays low again. I've tested it on both the XML file which caused the NLExtract server to run out of memory (begroeid terreindeel in bgt15.zip), as well as the biggest XML file in the same ZIP file (pand, containing 1545424 elements).