### PR TITLE
Fix for NLExtract memory issue, #211

### DIFF
--- a/stetl/filters/xmlelementreader.py
+++ b/stetl/filters/xmlelementreader.py
@@ -119,6 +119,10 @@ class XmlElementReader(Filter):
 
                     if self.strip_namespaces:
                         packet.data = Util.stripNamespaces(elem).getroot()
+                        
+                    # Clear the root element, since iterparse still builds a tree
+                    # See http://effbot.org/zone/element-iterparse.htm
+                    self.root.clear()
 
             # If there is a next component, let it process
             if self.next:


### PR DESCRIPTION
I was able to reproduce this easily by creating documents for BGT weginrichtingselementen (656k elements), while skipping the XSLT and OGR2OGR calls from BGT-extract. This fix was all that is necessary to keep memory consumption low.

See http://effbot.org/zone/element-iterparse.htm for more information. I chose for the solution to clear the root element, since we don't need the parsed elements anymore, after they have been transferred to the next process in the chain. My memory consumption stayed flat while processing this file.

Actually the deepcopy introduced by me earlier is responsible for the increase in memory consumption, but it was necessary to avoid the strange crashes we had which were caused by transferring elements from one XML doc to another. By just explicitely clearing the root element, this effect is countered.