### PR TITLE
Added gdal-bin to docker file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update && \
     libgdal-dev \
     build-essential \
     python-dev \
-    python-setuptools
+    python-setuptools \
+    gdal-bin
 
 # Get latest Stetl from git
 RUN git clone https://github.com/geopython/stetl /opt/stetl


### PR DESCRIPTION
Required for outputs.ogroutput.Ogr2OgrOutput. Without the ogr2ogr binary, this actions will fail (without a clear explanation about the underlying issue.