### PR TITLE
Make the build reproducible.

### DIFF
--- a/stetl/filters/templatingfilter.py
+++ b/stetl/filters/templatingfilter.py
@@ -139,7 +139,7 @@ class Jinja2TemplatingFilter(TemplatingFilter):
     # Applying Decorator pattern with the Config class to provide
     # read-only config values from the configured properties.
 
-    @Config(ptype=str, default=[os.getcwd()], required=False)
+    @Config(ptype=str, default=None, required=False)
     def template_search_paths(self):
         """
         List of directories where to search for templates, default is current working directory only.
@@ -207,7 +207,7 @@ class Jinja2TemplatingFilter(TemplatingFilter):
                     raise e
 
         # Load and Init Template once
-        loader = FileSystemLoader(self.template_search_paths)
+        loader = FileSystemLoader(self.template_search_paths or [os.getcwd()])
         self.jinja2_env = Environment(loader=loader, extensions=['jinja2.ext.do'], lstrip_blocks=True, trim_blocks=True)
 
         # Register additional Filters on the template environment by updating the filters dict:


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that python-stetl could not be built reproducibly.

This is because it embeds the current build path in its own
documentation.

This is also being tracked in Debian GNU/Linux[1].

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/881217