### PR TITLE
Update xmlelementreader.py

### DIFF
--- a/stetl/filters/xmlelementreader.py
+++ b/stetl/filters/xmlelementreader.py
@@ -114,7 +114,7 @@ class XmlElementReader(Filter):
 
                     # Clear the root element, since iterparse still builds a tree
                     # See http://effbot.org/zone/element-iterparse.htm
-                    self.root.clear()
+                    elem.clear()
 
             # If there is a next component, let it process
             if self.next:


### PR DESCRIPTION
when using self.root.clear() not all objects are imported into the database. Use elem.clear() instead.