### PR TITLE
Introduced env_args and env_separator config settings to outputs.execoutput.ExecOutput

### DIFF
--- a/stetl/outputs/execoutput.py
+++ b/stetl/outputs/execoutput.py
@@ -20,6 +20,22 @@ class ExecOutput(Output):
     Executes any command (abstract base class).
     """
 
+    @Config(ptype=str, default='', required=False)
+    def env_args(self):
+        """
+        Provides of list of environment variables which will be used when executing the given command.
+
+        Example: env_args = pgpassword=postgres othersetting=value~with~spaces
+        """
+        pass
+
+    @Config(ptype=str, default='=', required=False)
+    def env_separator(self):
+        """
+        Provides the separator to split the environment variable names from their values.
+        """
+        pass
+
     def __init__(self, configdict, section, consumes):
         Output.__init__(self, configdict, section, consumes)
 
@@ -31,9 +47,16 @@ class ExecOutput(Output):
         if os.name == 'nt':
             use_shell = False
 
-        log.info("executing cmd=%s" % cmd)
-        subprocess.call(cmd, shell=use_shell)
-        log.info("execute done")
+        env_vars = Util.string_to_dict(self.env_args, self.env_separator)
+        old_environ = os.environ.copy()
+
+        try:
+            os.environ.update(env_vars)
+            log.info("executing cmd=%s" % cmd)
+            subprocess.call(cmd, shell=use_shell)
+            log.info("execute done")
+        finally:
+            os.environ = old_environ
 
 
 class CommandExecOutput(ExecOutput):

--- a/tests/outputs/configs/commandexecoutput.cfg
+++ b/tests/outputs/configs/commandexecoutput.cfg
@@ -10,3 +10,5 @@ file_path = tests/data/command.txt
 [output_exec]
 class = outputs.execoutput.CommandExecOutput
 input_format = string
+env_args = pgpassword!postgres
+env_separator = !


### PR DESCRIPTION
The reason for this change is that I would like to call pg_restore in a command. For this to work properly you need to set the pgpassword environment variable, since with CommandExecOutput there is no way (known to me) to pass inputs. Alternatively I could have thought of a way to pass inputs to prompts, but this seems an easier way for this use case.

I have omitted nose2 tests, except for adding both new settings to the config file in test/configs. I didn't figure out a way how to check the enivornment variables during the execution of subprocess.call in  ExecOutput.execute_cmd.

The rationale behind adding these settings to ExecOutput instead of CommandExecOutput is that all subclasses of ExecOutput could benefit from this change. An example is Ogr2OgrExecOutput. Ogr2ogr uses some environment variables like GDAL_DATA.

Would it be a good idea to add these settings to ExecFilter as well? Note the code duplication. I'm not sure how to handle this nicely in Stetl...