### PR TITLE
Python2 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ _build/
 dist/
 htmlcov/
 Stetl.egg-info
+
+env2/
+env3/
+.idea

--- a/examples/basics/12_gdal_ogr/etl.cfg
+++ b/examples/basics/12_gdal_ogr/etl.cfg
@@ -61,6 +61,7 @@ output_format = ogr_feature_array
 
 [tolowercase_filter]
 class = tolowerfilter.ToLowerFilter
+stetl = False
 
 #
 # OUTPUTS

--- a/examples/basics/12_gdal_ogr/output/cities.gfs
+++ b/examples/basics/12_gdal_ogr/output/cities.gfs
@@ -1,0 +1,1 @@
+<GMLFeatureClassList />

--- a/examples/basics/7_mycomponent/etl.cfg
+++ b/examples/basics/7_mycomponent/etl.cfg
@@ -10,6 +10,7 @@ file_path = input/cities.xml
 # My custom component
 [my_filter]
 class = my.myfilter.MyFilter
+stetl = False
 
 [output_std]
 class = outputs.standardoutput.StandardXmlOutput

--- a/stetl/chain.py
+++ b/stetl/chain.py
@@ -4,12 +4,18 @@
 #
 # Author: Just van den Broecke
 #
-
-from factory import factory
-from packet import Packet
-from util import Util
-from splitter import Splitter
-from merger import Merger
+try:
+    from factory import factory
+    from packet import Packet
+    from util import Util
+    from splitter import Splitter
+    from merger import Merger
+except ImportError:
+    from stetl.factory import factory
+    from stetl.packet import Packet
+    from stetl.util import Util
+    from stetl.splitter import Splitter
+    from stetl.merger import Merger
 
 log = Util.get_log('chain')
 

--- a/stetl/component.py
+++ b/stetl/component.py
@@ -126,7 +126,7 @@ class Component(object):
 
         # The actual typed values as populated within Config Decorator
         try:
-            maxint  = sys.maxint
+            maxint = sys.maxint
         except AttributeError:
             maxint = sys.maxsize
 

--- a/stetl/component.py
+++ b/stetl/component.py
@@ -121,11 +121,16 @@ class Component(object):
         self.cfg = ConfigSection(configdict.items(section))
 
         # The actual typed values as populated within Config Decorator
+        try:
+            maxint  = sys.maxint
+        except AttributeError:
+            maxint = sys.maxsize
+
         self.cfg_vals = dict()
         self.next = None
         self.section = section
         self._max_time = -1
-        self._min_time = sys.maxint
+        self._min_time = maxint
         self._total_time = 0
         self._invoke_count = 0
 

--- a/stetl/component.py
+++ b/stetl/component.py
@@ -7,8 +7,12 @@
 import os
 import sys
 from time import time
-from util import Util, ConfigSection
-from packet import FORMAT
+try:
+    from util import Util, ConfigSection
+    from packet import FORMAT
+except ImportError:
+    from stetl.util import Util, ConfigSection
+    from stetl.packet import FORMAT
 
 log = Util.get_log('component')
 

--- a/stetl/etl.py
+++ b/stetl/etl.py
@@ -14,7 +14,7 @@ except ImportError:
 try:
     import version
 except ImportError:
-    from  stetl import version
+    from stetl import version
 try:
     from util import Util
 except ImportError:

--- a/stetl/etl.py
+++ b/stetl/etl.py
@@ -8,9 +8,9 @@ import os
 import re
 import sys
 try:
-    from ConfigParser import ConfigParser
+    from ConfigParser import ConfigParser, ExtendedInterpolation
 except ImportError:
-    from configparser import ConfigParser
+    from configparser import ConfigParser, ExtendedInterpolation
 import version
 from util import Util
 from chain import Chain
@@ -53,7 +53,7 @@ class ETL:
         ETL.CONFIG_DIR = os.path.dirname(os.path.abspath(config_file))
         log.info("Config/working dir = %s" % ETL.CONFIG_DIR)
 
-        self.configdict = ConfigParser()
+        self.configdict = ConfigParser(interpolation=ExtendedInterpolation())
 
         sys.path.append(ETL.CONFIG_DIR)
 

--- a/stetl/etl.py
+++ b/stetl/etl.py
@@ -84,7 +84,7 @@ class ETL:
 
             # Parse unique list of argument names from config file string.
             # https://www.machinelearningplus.com/python/python-regex-tutorial-examples/
-            args_names = list(set(re.findall('{[A-Z|a-z]\w+}', config_str)))
+            args_names = list(set(re.findall(r'{[A-Z|a-z]\w+}', config_str)))
             args_names = [name.split('{')[1].split('}')[0] for name in args_names]
 
             # Optional: expand from equivalent env vars

--- a/stetl/etl.py
+++ b/stetl/etl.py
@@ -11,9 +11,18 @@ try:
     from ConfigParser import ConfigParser, ExtendedInterpolation
 except ImportError:
     from configparser import ConfigParser, ExtendedInterpolation
-import version
-from util import Util
-from chain import Chain
+try:
+    import version
+except ImportError:
+    from  stetl import version
+try:
+    from util import Util
+except ImportError:
+    from stetl.util import Util
+try:
+    from chain import Chain
+except ImportError:
+    from stetl.chain import Chain
 try:
     from StringIO import StringIO
 except ImportError:

--- a/stetl/etl.py
+++ b/stetl/etl.py
@@ -7,11 +7,17 @@
 import os
 import re
 import sys
-from ConfigParser import ConfigParser
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
 import version
 from util import Util
 from chain import Chain
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 log = Util.get_log('ETL')
 
@@ -100,7 +106,7 @@ class ETL:
 
         try:
             # Put Config string into buffer (readfp() needs a readline() method)
-            config_buf = StringIO.StringIO(config_str)
+            config_buf = StringIO(config_str)
 
             # Parse config from file buffer
             self.configdict.readfp(config_buf, config_file)

--- a/stetl/factory.py
+++ b/stetl/factory.py
@@ -19,7 +19,9 @@ class Factory:
 
         # Get value for 'class' property
         class_string = configdict.get(section, 'class')
-        if not class_string.startswith('stetl.'):
+        # Check if this is a class from the non-standard stelt library
+        from_stetl_lib = configdict.getboolean(section, 'stetl', fallback=True)
+        if not class_string.startswith('stetl.') and from_stetl_lib:
             class_string = 'stetl.' + class_string
         try:
             if not class_string:

--- a/stetl/factory.py
+++ b/stetl/factory.py
@@ -25,7 +25,7 @@ class Factory:
 
             # class instance from class object with constructor args
             class_obj_inst = self.new_instance(class_obj, configdict, section)
-        except Exception, e:
+        except Exception as e:
             log.error("cannot create object instance from class '%s' e=%s" % (class_string, str(e)))
             raise e
 
@@ -46,8 +46,8 @@ class Factory:
             if module_name == '':
                 raise ValueError('Class name must contain module part.')
             class_obj = getattr(
-                __import__(module_name, globals(), locals(), [class_name], -1), class_name)
-        except Exception, e:
+                __import__(module_name, globals(), locals(), [class_name], 0), class_name)
+        except Exception as e:
             log.error("cannot create class '%s'" % class_string)
             raise e
 

--- a/stetl/factory.py
+++ b/stetl/factory.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from util import Util
+try:
+    from util import Util
+except ImportError:
+    from stetl.util import Util
 
 log = Util.get_log('factory')
 
@@ -16,6 +19,8 @@ class Factory:
 
         # Get value for 'class' property
         class_string = configdict.get(section, 'class')
+        if not class_string.startswith('stetl.'):
+            class_string = 'stetl.' + class_string
         try:
             if not class_string:
                 raise ValueError('Class name not defined in section %s.' % section)

--- a/stetl/filter.py
+++ b/stetl/filter.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Author: Just van den Broecke
 #
-from component import Component
-
+try:
+    from component import Component
+except ImportError:
+    from stetl.component import Component
 
 class Filter(Component):
     """

--- a/stetl/filter.py
+++ b/stetl/filter.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     from stetl.component import Component
 
+
 class Filter(Component):
     """
     Maps input to output. Abstract base class for specific Filters.

--- a/stetl/filters/formatconverter.py
+++ b/stetl/filters/formatconverter.py
@@ -209,7 +209,10 @@ class FormatConverter(Filter):
             for field_name in json_props:
 
                 # OGR needs UTF-8 internally
-                if isinstance(field_name, unicode):
+                if isinstance(field_name, str):
+                  #field_name is already utf8, since we're using python3
+                  pass
+                elif isinstance(field_name, unicode):
                     field_name = field_name.encode('utf8')
 
                 field_def = ogr.FieldDefn(field_name, ogr.OFTString)
@@ -221,7 +224,10 @@ class FormatConverter(Filter):
         # Create and populate Feature with id, geom and attributes
         feature = ogr.Feature(comp.feat_def)
         json_id = json_feat["id"]
-        if isinstance(json_id, unicode):
+        if isinstance(json_id, str):
+            # field_name is already utf8, since we're using python3
+            pass
+        elif isinstance(json_id, unicode):
             json_id = json_id.encode('utf8')
 
         feature.SetField("id", json_id)
@@ -229,15 +235,25 @@ class FormatConverter(Filter):
         for field_name in json_props:
 
             # OGR needs UTF-8 internally
-            field_value = json_props[field_name]
-            if isinstance(field_value, unicode):
+            field_value = str(json_props[field_name])
+            if isinstance(field_value, str):
+                # ok: python3
+                pass
+            elif isinstance(field_value, unicode):
                 field_value = field_value.encode('utf8')
 
-            if not isinstance(field_value, basestring):
+            try:
+                if not isinstance(field_value, basestring):
+                    field_value = str(field_value)
+            except NameError:
+                # python3
                 field_value = str(field_value)
 
             # OGR needs UTF-8 internally
-            if isinstance(field_name, unicode):
+            if isinstance(field_name, str):
+                #ok: python 3
+                pass
+            elif isinstance(field_name, unicode):
                 field_name = field_name.encode('utf8')
 
             # print("id=%s k=%s v=%s" % (json_id, field_name, field_value))

--- a/stetl/filters/formatconverter.py
+++ b/stetl/filters/formatconverter.py
@@ -210,8 +210,8 @@ class FormatConverter(Filter):
 
                 # OGR needs UTF-8 internally
                 if isinstance(field_name, str):
-                  #field_name is already utf8, since we're using python3
-                  pass
+                    # field_name is already utf8, since we're using python3
+                    pass
                 elif isinstance(field_name, unicode):
                     field_name = field_name.encode('utf8')
 
@@ -251,7 +251,7 @@ class FormatConverter(Filter):
 
             # OGR needs UTF-8 internally
             if isinstance(field_name, str):
-                #ok: python 3
+                # ok: python 3
                 pass
             elif isinstance(field_name, unicode):
                 field_name = field_name.encode('utf8')

--- a/stetl/filters/templatingfilter.py
+++ b/stetl/filters/templatingfilter.py
@@ -217,7 +217,7 @@ class Jinja2TemplatingFilter(TemplatingFilter):
                     else:
                         template_globals.update(globals_struct)
 
-                except Exception, e:
+                except Exception as e:
                     log.error('Cannot read JSON file, err= %s', str(e))
                     raise e
 
@@ -308,7 +308,7 @@ class Jinja2TemplatingFilter(TemplatingFilter):
                 options.append('GMLID=%s' % gml_id)
 
             gml_str = geom.ExportToGML(options=options)
-        except Exception, e:
+        except Exception as e:
             gml_str = 'Failure in CreateGeometryFromJson or ExportToGML, err= %s; check your data and Stetl log' % str(
                 e)
             log.error(gml_str)

--- a/stetl/filters/templatingfilter.py
+++ b/stetl/filters/templatingfilter.py
@@ -203,9 +203,13 @@ class Jinja2TemplatingFilter(TemplatingFilter):
                     log.info('Read JSON file with globals from: %s', file_path)
                     # Globals can come from local file or remote URL
                     if file_path.startswith('http'):
-                        import urllib2
+                        try:
+                            from urllib2 import urlopen
+                        except ImportError:
+                            # python 3
+                            from urllib.request import urlopen
 
-                        fp = urllib2.urlopen(file_path)
+                        fp = urlopen(file_path)
                         globals_struct = json.loads(fp.read())
                     else:
                         with open(file_path) as data_file:

--- a/stetl/filters/xmlassembler.py
+++ b/stetl/filters/xmlassembler.py
@@ -69,7 +69,7 @@ class XmlAssembler(Filter):
 
         # Start new doc (TODO clone)
         try:
-            etree_doc = etree.fromstring(self.container_doc, self.xml_parser)
+            etree_doc = etree.fromstring(str(self.container_doc), self.xml_parser)
         except Exception as e:
             log.error('new container doc not OK: %s' % str(e))
             return packet

--- a/stetl/filters/xmlassembler.py
+++ b/stetl/filters/xmlassembler.py
@@ -69,7 +69,7 @@ class XmlAssembler(Filter):
 
         # Start new doc (TODO clone)
         try:
-            etree_doc = etree.fromstring(str(self.container_doc), self.xml_parser)
+            etree_doc = etree.fromstring(self.container_doc.encode('utf-8'), self.xml_parser)
         except Exception as e:
             log.error('new container doc not OK: %s' % str(e))
             return packet

--- a/stetl/filters/xmlelementreader.py
+++ b/stetl/filters/xmlelementreader.py
@@ -12,6 +12,9 @@ from stetl.filter import Filter
 from stetl.util import Util, etree
 from stetl.packet import FORMAT
 
+#import StringIO
+from io import StringIO
+
 log = Util.get_log('xmlelementreader')
 
 
@@ -64,12 +67,13 @@ class XmlElementReader(Filter):
 
         if self.context is None:
             # Open file
-            fd = open(self.cur_file_path)
+            fd = open(self.cur_file_path, 'rb')
             self.elem_count = 0
             log.info("file opened : %s" % self.cur_file_path)
+
             self.context = etree.iterparse(fd, events=("start", "end"))
             self.context = iter(self.context)
-            event, self.root = self.context.next()
+            event, self.root = self.context.__next__()
 
         packet = self.process_xml(packet)
 
@@ -79,7 +83,7 @@ class XmlElementReader(Filter):
         while self.context is not None:
             # while not packet.is_end_of_doc():
             try:
-                event, elem = self.context.next()
+                event, elem = self.context.__next__()
             except (etree.XMLSyntaxError, StopIteration):
                 # workaround for etree.XMLSyntaxError https://bugs.launchpad.net/lxml/+bug/1185701
                 self.context = None

--- a/stetl/filters/xmlelementreader.py
+++ b/stetl/filters/xmlelementreader.py
@@ -73,7 +73,7 @@ class XmlElementReader(Filter):
 
             self.context = etree.iterparse(fd, events=("start", "end"))
             self.context = iter(self.context)
-            event, self.root = self.context.__next__()
+            event, self.root = next(self.context)
 
         packet = self.process_xml(packet)
 
@@ -83,7 +83,7 @@ class XmlElementReader(Filter):
         while self.context is not None:
             # while not packet.is_end_of_doc():
             try:
-                event, elem = self.context.__next__()
+                event, elem = next(self.context)
             except (etree.XMLSyntaxError, StopIteration):
                 # workaround for etree.XMLSyntaxError https://bugs.launchpad.net/lxml/+bug/1185701
                 self.context = None

--- a/stetl/filters/xmlelementreader.py
+++ b/stetl/filters/xmlelementreader.py
@@ -5,15 +5,13 @@
 #
 # Author: Frank Steggink
 #
+
 from copy import deepcopy
 
 from stetl.component import Config
 from stetl.filter import Filter
 from stetl.util import Util, etree
 from stetl.packet import FORMAT
-
-#import StringIO
-from io import StringIO
 
 log = Util.get_log('xmlelementreader')
 

--- a/stetl/input.py
+++ b/stetl/input.py
@@ -4,8 +4,12 @@
 #
 # Author: Just van den Broecke
 #
-from util import Util
-from component import Component
+try:
+    from util import Util
+    from component import Component
+except ImportError:
+    from stetl.util import Util
+    from stetl.component import Component
 
 log = Util.get_log('input')
 

--- a/stetl/inputs/fileinput.py
+++ b/stetl/inputs/fileinput.py
@@ -373,11 +373,17 @@ class CsvFileInput(FileInput):
 
     def read(self, packet):
         try:
-            packet.data = self.csv_reader.next()
+            try:  # python 2/3 solution
+                packet.data = self.csv_reader.__next__()
+            except AttributeError:
+                packet.data = self.csv_reader.next()
             if self._output_format == FORMAT.record_array:
                 while True:
                     self.arr.append(packet.data)
-                    packet.data = self.csv_reader.next()
+                    try:  # python 2/3 solution
+                        packet.data = self.csv_reader.__next__()
+                    except AttributeError:
+                        packet.data = self.csv_reader.next()
 
             log.info("CSV row nr %d read: %s" % (self.csv_reader.line_num - 1, packet.data))
         except Exception:

--- a/stetl/inputs/fileinput.py
+++ b/stetl/inputs/fileinput.py
@@ -209,10 +209,10 @@ class XmlElementStreamerFileInput(FileInput):
             log.info("file opened : %s" % self.cur_file_path)
             self.context = etree.iterparse(fd, events=("start", "end"))
             self.context = iter(self.context)
-            event, self.root = self.context.__next__()
+            event, self.root = next(self.context)
 
         try:
-            event, elem = self.context.__next__()
+            event, elem = next(self.context)
         except (etree.XMLSyntaxError, StopIteration):
             # workaround for etree.XMLSyntaxError https://bugs.launchpad.net/lxml/+bug/1185701
             self.context = None
@@ -377,17 +377,11 @@ class CsvFileInput(FileInput):
 
     def read(self, packet):
         try:
-            try:  # python 2/3 solution
-                packet.data = self.csv_reader.__next__()
-            except AttributeError:
-                packet.data = self.csv_reader.next()
+            packet.data = next(self.csv_reader)
             if self._output_format == FORMAT.record_array:
                 while True:
                     self.arr.append(packet.data)
-                    try:  # python 2/3 solution
-                        packet.data = self.csv_reader.__next__()
-                    except AttributeError:
-                        packet.data = self.csv_reader.next()
+                    packet.data = next(self.csv_reader)
 
             log.info("CSV row nr %d read: %s" % (self.csv_reader.line_num - 1, packet.data))
         except Exception:

--- a/stetl/inputs/fileinput.py
+++ b/stetl/inputs/fileinput.py
@@ -204,15 +204,15 @@ class XmlElementStreamerFileInput(FileInput):
 
             # Files available: pop next file
             self.cur_file_path = self.file_list.pop(0)
-            fd = open(self.cur_file_path)
+            fd = open(self.cur_file_path, 'rb')
             self.elem_count = 0
             log.info("file opened : %s" % self.cur_file_path)
             self.context = etree.iterparse(fd, events=("start", "end"))
             self.context = iter(self.context)
-            event, self.root = self.context.next()
+            event, self.root = self.context.__next__()
 
         try:
-            event, elem = self.context.next()
+            event, elem = self.context.__next__()
         except (etree.XMLSyntaxError, StopIteration):
             # workaround for etree.XMLSyntaxError https://bugs.launchpad.net/lxml/+bug/1185701
             self.context = None

--- a/stetl/inputs/fileinput.py
+++ b/stetl/inputs/fileinput.py
@@ -410,9 +410,13 @@ class JsonFileInput(FileInput):
             import json
             # may read/parse JSON from file or URL
             if file_path.startswith('http'):
-                import urllib2
+                try:
+                    from urllib2 import urlopen
+                except ImportError:
+                    # python 3
+                    from urllib.request import urlopen
 
-                fp = urllib2.urlopen(file_path)
+                fp = urlopen(file_path)
                 file_data = json.loads(fp.read())
             else:
                 with open(file_path) as data_file:

--- a/stetl/inputs/fileinput.py
+++ b/stetl/inputs/fileinput.py
@@ -307,7 +307,11 @@ class LineStreamerFileInput(FileInput):
 
             return packet
 
-        line = line.decode('utf-8')
+        try:
+            line = line.decode('utf-8')
+        except AttributeError:
+            # no need to decode
+            pass
         packet.data = self.process_line(line)
 
         return packet
@@ -366,7 +370,7 @@ class CsvFileInput(FileInput):
         log.info('Open CSV file: %s', self.file_path)
         self.file = open(self.file_path)
 
-        self.csv_reader = csv.DictReader(self.file, delimiter=self.delimiter, quotechar=self.quote_char)
+        self.csv_reader = csv.DictReader(self.file, delimiter=str(self.delimiter), quotechar=str(self.quote_char))
 
         if self._output_format == FORMAT.record_array:
             self.arr = list()

--- a/stetl/inputs/httpinput.py
+++ b/stetl/inputs/httpinput.py
@@ -5,8 +5,16 @@
 # Author: Just van den Broecke
 #
 import re
-from urllib2 import Request, urlopen, URLError, HTTPError
-import urllib
+try:
+    from urllib2 import Request, urlopen, URLError, HTTPError
+    from urllib import urlencode
+except ImportError:
+    # we are on python 3
+    # change to requests package?
+    from urllib.parse import urlencode
+    from urllib.request import Request, urlopen
+    from urllib.error import URLError, HTTPError
+
 import base64
 
 from stetl.component import Config
@@ -137,7 +145,7 @@ class HttpInput(Input):
             # Urlencode optional parameters
             query_string = None
             if parameters:
-                query_string = urllib.urlencode(parameters)
+                query_string = str.encode(urlencode(parameters))
 
             # Add optional Authorization
             if self.auth:

--- a/stetl/inputs/ogrinput.py
+++ b/stetl/inputs/ogrinput.py
@@ -103,7 +103,7 @@ class OgrInput(Input):
 
         # Open OGR data source in read-only mode.
         if self.source_format:
-            self.data_source_p = ogr.GetDriverByName(self.source_format).Open(self.data_source, 0)
+            self.data_source_p = ogr.GetDriverByName(str(self.source_format)).Open(self.data_source, 0)
         else:
             self.data_source_p = self.ogr.Open(self.data_source, 0)
 

--- a/stetl/main.py
+++ b/stetl/main.py
@@ -94,7 +94,7 @@ def print_classes(package):
         for name, data in inspect.getmembers(modname, inspect.isclass):
             if name == '__builtins__':
                 continue
-            print name, data
+            print(name, data)
 
 
 # DEPRECATED, now using @Config which also documents with Sphinx
@@ -112,7 +112,7 @@ def print_doc(class_name):
         # print ('\nConfiguration attributes: \n')
         # print_config_attrs(class_obj)
 
-    except Exception, e:
+    except Exception as e:
         log.error("cannot print info class named '%s' e=%s - you made a typo?" % (class_name, str(e)))
         raise e
 

--- a/stetl/main.py
+++ b/stetl/main.py
@@ -5,10 +5,17 @@
 #
 # Author: Just van den Broecke
 #
-from etl import ETL
-from factory import factory
-from util import Util
-from version import __version__
+try:
+    from etl import ETL
+    from factory import factory
+    from util import Util
+    from version import __version__
+except ImportError:
+    from stetl.etl import ETL
+    from stetl.factory import factory
+    from stetl.util import Util
+    from stetl.version import __version__
+
 import argparse  # apt-get install python-argparse
 import inspect
 import os

--- a/stetl/merger.py
+++ b/stetl/merger.py
@@ -6,8 +6,12 @@
 #
 
 import random
-from util import Util
-from component import Component
+try:
+    from util import Util
+    from component import Component
+except ImportError:
+    from stetl.util import Util
+    from stetl.component import Component
 
 log = Util.get_log('merger')
 

--- a/stetl/output.py
+++ b/stetl/output.py
@@ -4,8 +4,12 @@
 #
 # Author: Just van den Broecke
 #
-from component import Component
-from util import Util
+try:
+    from component import Component
+    from util import Util
+except ImportError:
+    from stetl.component import Component
+    from stetl.util import Util
 
 log = Util.get_log('output')
 

--- a/stetl/outputs/fileoutput.py
+++ b/stetl/outputs/fileoutput.py
@@ -46,7 +46,7 @@ class FileOutput(Output):
         log.info('writing to file %s' % file_path)
         out_file = open(file_path, 'w')
 
-        out_file.write(packet.to_string())
+        out_file.write(str(packet.to_string()))
 
         out_file.close()
         log.info("written to %s" % file_path)

--- a/stetl/outputs/ogroutput.py
+++ b/stetl/outputs/ogroutput.py
@@ -180,7 +180,7 @@ class OgrOutput(Output):
         if self.dest_driver is None:
 
             # Open OGR data dest in write-only mode.
-            self.dest_driver = ogr.GetDriverByName(self.dest_format)
+            self.dest_driver = ogr.GetDriverByName(str(self.dest_format))
 
             # Report failure if failed
             if self.dest_driver is None:
@@ -214,7 +214,7 @@ class OgrOutput(Output):
                 log.error("Failed to process SRS definition: %s" % self.target_srs)
             raise Exception()
 
-        self.layer = self.dest_fd.CreateLayer(self.new_layer_name, output_srs_ref, ogr.wkbUnknown,
+        self.layer = self.dest_fd.CreateLayer(str(self.new_layer_name), output_srs_ref, ogr.wkbUnknown,
                                               self.layer_create_options)
         self.feature_def = None
 

--- a/stetl/outputs/ogroutput.py
+++ b/stetl/outputs/ogroutput.py
@@ -303,7 +303,7 @@ class Ogr2OgrOutput(Output):
 
         log.info('writing to file %s' % file_path)
         out_file = open(file_path, 'w')
-        out_file.writelines(packet.to_string())
+        out_file.writelines(str(packet.to_string()))
         out_file.close()
 
         # Copy the .gfs file if required, use the same base name

--- a/stetl/outputs/standardoutput.py
+++ b/stetl/outputs/standardoutput.py
@@ -27,7 +27,7 @@ class StandardOutput(Output):
             return packet
 
         # Default: print to stdout
-        print(packet.to_string().decode('utf-8'))
+        print(packet.to_string())
         return packet
 
 
@@ -46,5 +46,5 @@ class StandardXmlOutput(Output):
             return packet
 
         # Default: print to stdout
-        print(packet.to_string().decode('utf-8'))
+        print(packet.to_string())
         return packet

--- a/stetl/outputs/standardoutput.py
+++ b/stetl/outputs/standardoutput.py
@@ -27,7 +27,7 @@ class StandardOutput(Output):
             return packet
 
         # Default: print to stdout
-        print(packet.to_string())
+        print(packet.to_string().decode('utf-8'))
         return packet
 
 
@@ -46,5 +46,5 @@ class StandardXmlOutput(Output):
             return packet
 
         # Default: print to stdout
-        print(packet.to_string())
+        print(packet.to_string().decode('utf-8'))
         return packet

--- a/stetl/packet.py
+++ b/stetl/packet.py
@@ -53,7 +53,7 @@ class Packet:
             s = json.dumps(self.data, sort_keys=False, indent=4, separators=(',', ': '))
         elif self.format == FORMAT.ogr_feature:
             s = self.data.ExportToJson()
-        elif type(self.data) is str:
+        elif type(self.data) in [str, list]:
             s = self.data
         else:
             s = str(self.data.decode('utf-8'))

--- a/stetl/packet.py
+++ b/stetl/packet.py
@@ -50,7 +50,7 @@ class Packet:
         if self.format == FORMAT.etree_doc:
             s = etree.tostring(self.data, pretty_print=True, xml_declaration=True, encoding='utf-8').decode('utf-8')
         elif self.format == FORMAT.struct or self.format == FORMAT.geojson_collection or self.format == FORMAT.geojson_feature:
-            s = json.dumps(self.data, sort_keys=False, indent=4, separators=(',', ': ')).decode('utf-8')
+            s = json.dumps(self.data, sort_keys=False, indent=4, separators=(',', ': '))
         elif self.format == FORMAT.ogr_feature:
             s = self.data.ExportToJson()
         elif type(self.data) is str:

--- a/stetl/packet.py
+++ b/stetl/packet.py
@@ -44,7 +44,7 @@ class Packet:
 
     def to_string(self, args=dict):
         if self.data is None:
-            return ''
+            return ''.decode('utf-8')
 
         # TODO: jumptable
         if self.format == FORMAT.etree_doc:
@@ -55,7 +55,7 @@ class Packet:
             s = self.data.ExportToJson()
         else:
             s = str(self.data)
-        return s
+        return s.decode('utf-8')
 
 
 # Simple enum emulation NOT ANY MORE: TOO INVOLVED AND INFLEXIBLE: use Strings with predefined ones in FORMAT.*

--- a/stetl/packet.py
+++ b/stetl/packet.py
@@ -53,6 +53,8 @@ class Packet:
             s = json.dumps(self.data, sort_keys=False, indent=4, separators=(',', ': ')).decode('utf-8')
         elif self.format == FORMAT.ogr_feature:
             s = self.data.ExportToJson()
+        elif type(self.data) is str:
+            s = self.data
         else:
             s = str(self.data.decode('utf-8'))
         return s

--- a/stetl/packet.py
+++ b/stetl/packet.py
@@ -53,8 +53,10 @@ class Packet:
             s = json.dumps(self.data, sort_keys=False, indent=4, separators=(',', ': '))
         elif self.format == FORMAT.ogr_feature:
             s = self.data.ExportToJson()
-        elif type(self.data) in [str, list]:
-            s = self.data
+        elif type(self.data) is str:
+            s = str(self.data)
+        elif type(self.data) is list:
+                s = json.dumps(self.data)  # fixes python3 OrderedDict
         else:
             s = str(self.data.decode('utf-8'))
         return s

--- a/stetl/packet.py
+++ b/stetl/packet.py
@@ -48,14 +48,14 @@ class Packet:
 
         # TODO: jumptable
         if self.format == FORMAT.etree_doc:
-            s = etree.tostring(self.data, pretty_print=True, xml_declaration=True, encoding='utf-8')
+            s = etree.tostring(self.data, pretty_print=True, xml_declaration=True, encoding='utf-8').decode('utf-8')
         elif self.format == FORMAT.struct or self.format == FORMAT.geojson_collection or self.format == FORMAT.geojson_feature:
-            s = json.dumps(self.data, sort_keys=False, indent=4, separators=(',', ': '))
+            s = json.dumps(self.data, sort_keys=False, indent=4, separators=(',', ': ')).decode('utf-8')
         elif self.format == FORMAT.ogr_feature:
             s = self.data.ExportToJson()
         else:
-            s = str(self.data)
-        return s.decode('utf-8')
+            s = str(self.data.decode('utf-8'))
+        return s
 
 
 # Simple enum emulation NOT ANY MORE: TOO INVOLVED AND INFLEXIBLE: use Strings with predefined ones in FORMAT.*

--- a/stetl/packet.py
+++ b/stetl/packet.py
@@ -4,7 +4,10 @@
 #
 # Author: Just van den Broecke
 #
-from util import etree
+try:
+    from util import etree
+except ImportError:
+    from stetl.util import etree
 import json
 
 
@@ -48,17 +51,21 @@ class Packet:
 
         # TODO: jumptable
         if self.format == FORMAT.etree_doc:
-            s = etree.tostring(self.data, pretty_print=True, xml_declaration=True, encoding='utf-8').decode('utf-8')
+            s = etree.tostring(self.data, pretty_print=True, xml_declaration=True, encoding='utf-8')
         elif self.format == FORMAT.struct or self.format == FORMAT.geojson_collection or self.format == FORMAT.geojson_feature:
             s = json.dumps(self.data, sort_keys=False, indent=4, separators=(',', ': '))
         elif self.format == FORMAT.ogr_feature:
             s = self.data.ExportToJson()
         elif type(self.data) is str:
             s = str(self.data)
-        elif type(self.data) is list:
-                s = json.dumps(self.data)  # fixes python3 OrderedDict
+        elif type(self.data) in (list, dict):
+            s = json.dumps(self.data)
         else:
-            s = str(self.data.decode('utf-8'))
+            try:
+                s = str(self.data.decode('utf-8'))
+            except AttributeError:
+                # not all types have a decode method
+                s = str(self.data)
         return s
 
 

--- a/stetl/postgis.py
+++ b/stetl/postgis.py
@@ -4,7 +4,10 @@
 #
 # Author: Just van den Broecke
 #
-from util import Util
+try:
+    from util import Util
+except ImportError:
+    from stetl.util import Util
 
 log = Util.get_log("postgis")
 

--- a/stetl/splitter.py
+++ b/stetl/splitter.py
@@ -6,8 +6,12 @@
 #
 
 import random
-from util import Util
-from component import Component
+try:
+    from util import Util
+    from component import Component
+except ImportError:
+    from stetl.util import Util
+    from stetl.component import Component
 
 log = Util.get_log('splitter')
 

--- a/stetl/util.py
+++ b/stetl/util.py
@@ -10,7 +10,10 @@ import os
 import re
 import types
 from time import time
-from ConfigParser import ConfigParser
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
 
 logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s %(name)s %(levelname)s %(message)s')
@@ -385,9 +388,14 @@ try:
 
     log.info("Found cStringIO, good!")
 except Exception:
-    from StringIO import StringIO
+    try:
+        from StringIO import StringIO
 
-    log.warning("Found %s - this is suboptimal, try cStringIO" % str(type(StringIO)))
+        log.warning("Found %s - this is suboptimal, try cStringIO" % str(type(StringIO)))
+    except ImportError:
+        from io import StringIO
+
+        log.warning("Found %s - this is suboptimal, try cStringIO" % str(type(StringIO)))
 
 try:
     from lxml import etree

--- a/stetl/util.py
+++ b/stetl/util.py
@@ -10,10 +10,7 @@ import os
 import re
 import types
 from time import time
-try:
-    from ConfigParser import ConfigParser
-except ImportError:
-    from configparser import ConfigParser
+from configparser import ConfigParser
 
 logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s %(name)s %(levelname)s %(message)s')
@@ -151,10 +148,23 @@ class Util:
                     finally:
                         self.sechead = None
                 else:
-                    return self.fp.readline()
+                    line = self.fp.readline()
+                    if line:
+                        return line
+                    else:
+                        raise StopIteration
+
+            def __iter__(self):
+                return self
+
+            def next(self):
+                return self.readline()
+
+            def __next__(self):
+                return self.next()
 
         cp = ConfigParser()
-        cp.readfp(FakeSecHead(open(file_path)))
+        cp.read_file(FakeSecHead(open(file_path)))
         return cp._sections['asection']
 
     @staticmethod

--- a/stetl/util.py
+++ b/stetl/util.py
@@ -251,6 +251,7 @@ class Util:
                 # Create OGR Geometry object from GML string
                 value = etree.tostring(subelem)
                 from osgeo import ogr
+                value = str(value.decode('utf-8')) if type(value) is bytes else value
                 geom = ogr.CreateGeometryFromGML(value)
 
                 value = geom

--- a/stetl/utils/apachelog.py
+++ b/stetl/utils/apachelog.py
@@ -162,7 +162,7 @@ class parser:
 
             self._names.append(self.alias(element))
 
-            subpattern = '(\S*)'
+            subpattern = r'(\S*)'
 
             if hasquotes:
                 if element == '%r' or findreferreragent.search(element):

--- a/tests/data/commandexecfilter.txt
+++ b/tests/data/commandexecfilter.txt
@@ -1,1 +1,1 @@
-python -c "print '{0}/{1}'.format('foo','bar')"
+python -c "print('{0}/{1}'.format('foo','bar'))"

--- a/tests/filters/test_command_exec_filter.py
+++ b/tests/filters/test_command_exec_filter.py
@@ -35,4 +35,4 @@ class CommandExecFilterTest(StetlTestCase):
         buffer_filter = chain.get_by_class(PacketBuffer)
         packet_list = buffer_filter.packet_list
 
-        self.assertEqual(packet_list[0].data.strip(), "foo/bar")
+        self.assertEqual(packet_list[0].data.strip().decode('utf-8'), "foo/bar")

--- a/tests/filters/test_regex_filter.py
+++ b/tests/filters/test_regex_filter.py
@@ -35,4 +35,5 @@ class RegexFilterTest(StetlTestCase):
         buffer_filter = chain.get_by_class(PacketBuffer)
         packet_list = buffer_filter.packet_list
 
-        self.assertEqual(str(packet_list[0].data), "{'elemtype': 'BuildingInstallation', 'featurecount': '1162'}")
+        self.assertTrue(str(packet_list[0].data)=="{'elemtype': 'BuildingInstallation', 'featurecount': '1162'}" or
+                        str(packet_list[0].data)=="{u'elemtype': 'BuildingInstallation', u'featurecount': '1162'}")

--- a/tests/inputs/test_merger_multi_input.py
+++ b/tests/inputs/test_merger_multi_input.py
@@ -6,6 +6,7 @@ from stetl.inputs.fileinput import LineStreamerFileInput
 from stetl.filters.nullfilter import NullFilter
 from stetl.outputs.standardoutput import StandardOutput
 from stetl.merger import Merger
+from stetl import merger
 from tests.stetl_test_case import StetlTestCase
 
 
@@ -26,7 +27,7 @@ class MergerMultiInputTest(StetlTestCase):
         chain = StetlTestCase.get_chain(self.etl)
 
         merger_comp = chain.first_comp
-        self.assertTrue(isinstance(merger_comp, Merger))
+        self.assertTrue(isinstance(merger_comp, merger.Merger))
         self.assertEqual(len(merger_comp.children), 2)
         self.assertTrue(isinstance(merger_comp.children[0][0], LineStreamerFileInput),
                         "Next is not LineStreamerFileInput")

--- a/tests/outputs/test_standard_output.py
+++ b/tests/outputs/test_standard_output.py
@@ -38,6 +38,6 @@ class StandardOutputTest(StetlTestCase):
         
         self.etl.run()
         
-        self.assertGreater(sys.stdout.getvalue(), 0)
+        self.assertGreater(sys.stdout.getvalue(), str(0))
         # Assert includes last linebreak from stdout, due to print function
         self.assertEqual(sys.stdout.getvalue(), contents + '\n')

--- a/tests/stetl_test_case.py
+++ b/tests/stetl_test_case.py
@@ -5,7 +5,10 @@ import unittest
 
 from stetl.chain import Chain
 from stetl.util import Util
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 


### PR DESCRIPTION
With the official support for python2 ending within a year (https://www.python.org/dev/peps/pep-0373/#id4), I totally agree with @sebastic: it's time to add python3 compatibility - see issue #23 .

I prepared a merge request for Stetl to work with both python2 and python3. All of the nosetests and all of the basic examples are working under both versions. Is there more to check?

A very unfortunate change I had to make is the use of 'custom' filters that are not included in the stetl library. For instance in basic example 12: I added `stetl=False` in the `etl.cfg` file. This was necessary for chaining the steps together in `stetl/factory.py`, line 23. Not ideal at all since it migth break other tools using stetl.

Please: any suggestions, comments or ideas are welcome. I assume there will be some discussion and changes before it will be merged.