### PR TITLE
Fix typo in example config

### DIFF
--- a/examples/top10nl/etl-top10nl.cfg
+++ b/examples/top10nl/etl-top10nl.cfg
@@ -29,7 +29,7 @@ chains = input_sql_pre|schema_name_filter|output_postgres,
 
 # Pre SQL file inputs to be executed
 [input_sql_pre]
-class =stetl. inputs.fileinput.StringFileInput
+class = stetl.inputs.fileinput.StringFileInput
 file_path = sql/drop-tables.sql,sql/create-schema.sql
 
 # Post SQL file inputs to be executed
@@ -51,7 +51,7 @@ port = {port}
 user     = {user}
 password = {password}
 schema = {schema}
-
+examples/top10nl/etl-top10nl.cfg
 # The source input file(s) from dir and produce gml:featureMember elements
 [input_big_gml_files]
 class = stetl.inputs.fileinput.XmlElementStreamerFileInput


### PR DESCRIPTION
`s/class =stetl. inputs/class = stetl.inputs/`