### PR TITLE
Use python3 interpreter in test

### DIFF
--- a/tests/data/commandexecfilter.txt
+++ b/tests/data/commandexecfilter.txt
@@ -1,1 +1,1 @@
-python -c "print('{0}/{1}'.format('foo','bar'))"
+python3 -c "print('{0}/{1}'.format('foo','bar'))"


### PR DESCRIPTION
Per [PEP 394](https://www.python.org/dev/peps/pep-0394/#abstract):
> * python3 will refer to some version of Python 3.x.
> * for the time being, all distributions should ensure that python, if installed, refers to the same target as python2, unless the user deliberately overrides this or a virtual environment is active.