### PR TITLE
Fixes #97: WFS endpoint updated

### DIFF
--- a/examples/basics/8_wfs/etl.cfg
+++ b/examples/basics/8_wfs/etl.cfg
@@ -5,7 +5,7 @@ chains = input_wfs|output_std
 
 [input_wfs]
 class = stetl.inputs.httpinput.HttpInput
-url = http://geodata.nationaalgeoregister.nl/bag/wfs
+url = https://geodata.nationaalgeoregister.nl/bag/wfs/v1_1
 parameters = {
 		'service' : 'WFS',
 		'version' : '1.1.0',


### PR DESCRIPTION
Test output (from a Docker container on Windows):
```
root@0150a77f6ae8:/# stetl -c etl.cfg
2020-07-21 08:00:55,964 util INFO Found lxml.etree, native XML parsing, fabulous!
2020-07-21 08:00:55,986 util INFO Found GDAL/OGR Python bindings, super!!
2020-07-21 08:00:55,991 main INFO Stetl version = 2.0
2020-07-21 08:00:55,992 ETL INFO INIT - Stetl version is 2.0
2020-07-21 08:00:55,992 ETL INFO Config/working dir = /
2020-07-21 08:00:55,992 ETL INFO Reading config_file = etl.cfg
2020-07-21 08:00:55,993 ETL INFO START
2020-07-21 08:00:55,993 util INFO Timer start: total ETL
2020-07-21 08:00:55,993 chain INFO Assembling Chain: input_wfs|output_std...
2020-07-21 08:00:56,002 input INFO cfg = {'class': 'stetl.inputs.httpinput.HttpInput', 'url': 'https://geodata.nationaalgeoregister.nl/bag/wfs/v1_1', 'parameters': '{\n\'service\' : \'WFS\',\n\'version\' : \'1.1.0\',\n\'request\' : \'GetFeature\',\n\'srsName\' : \'EPSG:2
8992\',\n\'outputFormat\' : \'text/xml; subtype=gml/2.1.2\',\n\'typename\' : \'verblijfsobject\',\n\'filter\' :\'<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"><ogc:BBOX><gml:Envelope xmlns:gml="http://www.opengis.net/gml" srsName="EPSG:28992"><gml:lowerCorner>183774
.83 450577.24</gml:lowerCorner><gml:upperCorner>184277.99 450809.92</gml:upperCorner></gml:Envelope></ogc:BBOX></ogc:Filter>\'\n}'}
2020-07-21 08:00:56,002 httpinput INFO url=https://geodata.nationaalgeoregister.nl/bag/wfs/v1_1 parameters={'service': 'WFS', 'version': '1.1.0', 'request': 'GetFeature', 'srsName': 'EPSG:28992', 'outputFormat': 'text/xml; subtype=gml/2.1.2', 'typename': 'verblijfsobject
', 'filter': '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"><ogc:BBOX><gml:Envelope xmlns:gml="http://www.opengis.net/gml" srsName="EPSG:28992"><gml:lowerCorner>183774.83 450577.24</gml:lowerCorner><gml:upperCorner>184277.99 450809.92</gml:upperCorner></gml:Envelope
></ogc:BBOX></ogc:Filter>'}
2020-07-21 08:00:56,004 output INFO cfg = {'class': 'stetl.outputs.standardoutput.StandardOutput'}
2020-07-21 08:00:56,004 chain INFO Running Chain: input_wfs|output_std
b'<?xml version=\'1.0\' encoding="UTF-8" ?>\n<wfs:FeatureCollection\n   xmlns:bag="http://bag.geonovum.nl"\n   xmlns:wfs="http://www.opengis.net/wfs"\n   xmlns:gml="http://www.opengis.net/gml"\n   xmlns:ogc="http://www.opengis.net/ogc"\n   xmlns:xsi="http://www.w3.org/20
01/XMLSchema-instance"\n   xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/WFS-basic.xsd \n                       http://bag.geonovum.nl https://geodata.nationaalgeoregister.nl/bag/wfs/v1_1?SERVICE=WFS&amp;SERVICE=WFS&amp;VERSION=1.1.0
&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=verblijfsobject&amp;OUTPUTFORMAT=XMLSCHEMA">\n      <gml:boundedBy>\n      \t<gml:Box srsName="EPSG:28992">\n      \t\t<gml:coordinates>183936.000000,450637.000000 183987.000000,450673.000000</gml:coordinates>\n      \t</gml:
Box>\n      </gml:boundedBy>\n    <gml:featureMember>\n      <bag:verblijfsobject fid="verblijfsobject.bag:0228010000047219">\n        <gml:boundedBy>\n        \t<gml:Box srsName="EPSG:28992">\n        \t\t<gml:coordinates>183936.000000,450637.000000 183936.000000,450637
.000000</gml:coordinates>\n        \t</gml:Box>\n        </gml:boundedBy>\n        <bag:geometrie>\n        <gml:Point srsName="EPSG:28992">\n          <gml:coordinates>183936.000000,450637.000000</gml:coordinates>\n        </gml:Point>\n        </bag:geometrie>\n
 <bag:gid>7753769</bag:gid>\n        <bag:identificatie>0228010000047219</bag:identificatie>\n        <bag:oppervlakte>121</bag:oppervlakte>\n        <bag:status>Verblijfsobject in gebruik</bag:status>\n        <bag:gebruiksdoel>woonfunctie</bag:gebruiksdoel>\n        <b
ag:openbare_ruimte>Harderwijkerweg</bag:openbare_ruimte>\n        <bag:huisnummer>1</bag:huisnummer>\n        <bag:huisletter></bag:huisletter>\n        <bag:toevoeging></bag:toevoeging>\n        <bag:postcode>6731ST</bag:postcode>\n        <bag:woonplaats>Otterlo</bag:w
oonplaats>\n        <bag:bouwjaar>1947</bag:bouwjaar>\n        <bag:pandidentificatie>0228100000027383</bag:pandidentificatie>\n        <bag:pandstatus>Pand in gebruik</bag:pandstatus>\n        <bag:rdf_seealso>http://bag.basisregistraties.overheid.nl/bag/id/verblijfsobj
ect/0228010000047219</bag:rdf_seealso>\n      </bag:verblijfsobject>\n    </gml:featureMember>\n    <gml:featureMember>\n      <bag:verblijfsobject fid="verblijfsobject.bag:0228010000047281">\n        <gml:boundedBy>\n        \t<gml:Box srsName="EPSG:28992">\n        \t\
t<gml:coordinates>183987.000000,450673.000000 183987.000000,450673.000000</gml:coordinates>\n        \t</gml:Box>\n        </gml:boundedBy>\n        <bag:geometrie>\n        <gml:Point srsName="EPSG:28992">\n          <gml:coordinates>183987.000000,450673.000000</gml:coo
rdinates>\n        </gml:Point>\n        </bag:geometrie>\n        <bag:gid>7753830</bag:gid>\n        <bag:identificatie>0228010000047281</bag:identificatie>\n        <bag:oppervlakte>71</bag:oppervlakte>\n        <bag:status>Verblijfsobject in gebruik</bag:status>\n
     <bag:gebruiksdoel>woonfunctie</bag:gebruiksdoel>\n        <bag:openbare_ruimte>Harderwijkerweg</bag:openbare_ruimte>\n        <bag:huisnummer>2</bag:huisnummer>\n        <bag:huisletter></bag:huisletter>\n        <bag:toevoeging></bag:toevoeging>\n        <bag:postc
ode>6731ST</bag:postcode>\n        <bag:woonplaats>Otterlo</bag:woonplaats>\n        <bag:bouwjaar>1947</bag:bouwjaar>\n        <bag:pandidentificatie>0228100000006908</bag:pandidentificatie>\n        <bag:pandstatus>Pand in gebruik</bag:pandstatus>\n        <bag:rdf_see
also>http://bag.basisregistraties.overheid.nl/bag/id/verblijfsobject/0228010000047281</bag:rdf_seealso>\n      </bag:verblijfsobject>\n    </gml:featureMember>\n</wfs:FeatureCollection>\n\n'
2020-07-21 08:00:56,158 httpinput INFO EOF URL reading done
2020-07-21 08:00:56,158 component INFO HttpInput invokes=2 time(total, min, max, avg) = 0.154 0.154 0.154 0.077
2020-07-21 08:00:56,158 component INFO StandardOutput invokes=2 time(total, min, max, avg) = 0.000 9223372036854775808.000 0.000 0.000
2020-07-21 08:00:56,158 chain INFO DONE - 2 rounds - chain=input_wfs|output_std
2020-07-21 08:00:56,159 util INFO Timer end: total ETL time=0.0 sec
2020-07-21 08:00:56,159 ETL INFO ALL DONE
root@0150a77f6ae8:/# echo $?
0
```