### PR TITLE
Fixes #107 implement StringConcatFilter with unit tests

### DIFF
--- a/stetl/filters/stringfilter.py
+++ b/stetl/filters/stringfilter.py
@@ -65,3 +65,46 @@ class StringSubstitutionFilter(StringFilter):
         # String substitution based on Python String.format()
         packet.data = packet.data.format(**self.format_args_dict)
         return packet
+
+
+class StringConcatFilter(StringFilter):
+    """
+    Concatenates a specified string with the input string (packet.data) either/or as prefix (prepend)
+    or postfix (append) and outputs that concatenation.
+
+    consumes=FORMAT.string, produces=FORMAT.string
+    """
+
+    @Config(ptype=str, default=None, required=False)
+    def append_string(self):
+        """
+        String to be appended.
+
+        Example: append_string = /002PND150904.xml
+        """
+        pass
+
+    @Config(ptype=str, default=None, required=False)
+    def prepend_string(self):
+        """
+        String to be prepended.
+
+        Example: prepend_string = /vsizip/
+        """
+        pass
+
+    # Constructor
+    def __init__(self, configdict, section):
+        StringFilter.__init__(self, configdict, section, consumes=FORMAT.string, produces=FORMAT.string)
+
+    def filter_string(self, packet):
+        if not packet.data:
+            return
+
+        if self.append_string:
+            packet.data = packet.data + self.append_string
+
+        if self.prepend_string:
+            packet.data = self.prepend_string + packet.data
+
+        return packet

--- a/tests/data/stringfileinput_plainstring.txt
+++ b/tests/data/stringfileinput_plainstring.txt
@@ -1,0 +1,1 @@
+temp/bagobject.zip

--- a/tests/filters/configs/stringconcatfilter.cfg
+++ b/tests/filters/configs/stringconcatfilter.cfg
@@ -1,0 +1,19 @@
+# Config file for unit testing StringSubstitutionFilter.
+
+[etl]
+chains = input_string_file|string_concat_filter|packet_buffer|output_std
+
+[input_string_file]
+class = stetl.inputs.fileinput.StringFileInput
+file_path = tests/data/stringfileinput_plainstring.txt
+
+[string_concat_filter]
+class = stetl.filters.stringfilter.StringConcatFilter
+prepend_string = /vsizip/
+append_string = /pand.xml
+
+[packet_buffer]
+class = stetl.filters.packetbuffer.PacketBuffer
+
+[output_std]
+class = stetl.outputs.standardoutput.StandardOutput

--- a/tests/filters/test_string_concat_filter.py
+++ b/tests/filters/test_string_concat_filter.py
@@ -1,0 +1,38 @@
+import os
+
+from stetl.etl import ETL
+from stetl.filters.packetbuffer import PacketBuffer
+from stetl.filters.stringfilter import StringConcatFilter
+from tests.stetl_test_case import StetlTestCase
+
+class StringConcatFilterTest(StetlTestCase):
+    """Unit tests for StringConcatFilter"""
+
+    def setUp(self):
+        super(StringConcatFilterTest, self).setUp()
+
+        # Initialize Stetl
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        cfg_dict = {'config_file': os.path.join(curr_dir, 'configs/stringconcatfilter.cfg')}
+        self.etl = ETL(cfg_dict)
+    
+    def test_class(self):
+        chain = StetlTestCase.get_chain(self.etl)
+        section = StetlTestCase.get_section(chain, 1)
+        class_name = self.etl.configdict.get(section, 'class')
+        
+        self.assertEqual('stetl.filters.stringfilter.StringConcatFilter', class_name)
+    
+    def test_instance(self):
+        chain = StetlTestCase.get_chain(self.etl)
+
+        self.assertTrue(isinstance(chain.get_by_index(1), StringConcatFilter))
+        
+    def test_execute(self):
+        chain = StetlTestCase.get_chain(self.etl)
+        chain.run()
+
+        buffer_filter = chain.get_by_class(PacketBuffer)
+        packet_list = buffer_filter.packet_list
+
+        self.assertEqual(packet_list[0].data, '/vsizip/temp/bagobject.zip/pand.xml')


### PR DESCRIPTION
Simple multi-purpose Filter, now mainly for filepath alteration for OGR `/vsi*`.