### PR TITLE
Use read_file() instead of readfp().

### DIFF
--- a/stetl/util.py
+++ b/stetl/util.py
@@ -159,7 +159,7 @@ class Util:
                         raise StopIteration
 
         cp = ConfigParser()
-        cp.readfp(FakeSecHead(open(file_path)))
+        cp.read_file(FakeSecHead(open(file_path)))
         return cp._sections['asection']
 
     @staticmethod


### PR DESCRIPTION
Fixes AttributeError with Python 3.12.

As reported in [Debian Bug #1058164](https://bugs.debian.org/1058164), the package failed to build with Python 3.12.

The `readfp()` method has been deprecated since 3.2:
> Deprecated since version 3.2: Use [read_file()](https://docs.python.org/3.11/library/configparser.html#configparser.ConfigParser.read_file) instead.