### PR TITLE
remove usage of old external "mock"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 nose2
 cov-core
-mock
 Sphinx
 flake8
 pylint

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,7 +30,9 @@ The test coverage is written to the dir htmlcov.
 
 Mock objects: mock
 
-	pip install mock
+    mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.
+
+    https://github.com/testing-cabal/mock
 
 More information: http://www.voidspace.org.uk/python/mock/
 

--- a/tests/filters/test_vsi_file_extractor.py
+++ b/tests/filters/test_vsi_file_extractor.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 
 from stetl.etl import ETL

--- a/tests/filters/test_vsifilter.py
+++ b/tests/filters/test_vsifilter.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import shutil
 import sys

--- a/tests/filters/test_zip_archive_expander.py
+++ b/tests/filters/test_zip_archive_expander.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 
 from stetl.etl import ETL

--- a/tests/filters/test_zip_file_extractor.py
+++ b/tests/filters/test_zip_file_extractor.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 
 from stetl.etl import ETL

--- a/tests/outputs/test_command_exec_output.py
+++ b/tests/outputs/test_command_exec_output.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import sys
 

--- a/tests/outputs/test_ogr2ogr_exec_output.py
+++ b/tests/outputs/test_ogr2ogr_exec_output.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import shutil
 import sys

--- a/tests/outputs/test_ogr2ogr_exec_output_lco.py
+++ b/tests/outputs/test_ogr2ogr_exec_output_lco.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import shutil
 import sys

--- a/tests/outputs/test_postgres_db_output.py
+++ b/tests/outputs/test_postgres_db_output.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import sys
 


### PR DESCRIPTION
+    mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.
+
+    https://github.com/testing-cabal/mock
